### PR TITLE
make getter for RecordRefIter public

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -212,7 +212,8 @@ impl<'a, R: 'a + Read> Parser<R> {
         }
     }
 
-    fn ref_iter(self) -> RecordRefIter<R> {
+    /// Get a RecordRefIter for this parser. Should only be used in custom iteration scenarios.
+    pub fn ref_iter(self) -> RecordRefIter<R> {
         RecordRefIter {
             parser: self,
             current_length: None,


### PR DESCRIPTION
I need this for a scenario where I'm iterating over up to 4 FASTQs and want to control the iteration myself.  The use case is a general Illumina 'cluster' reader, where each 'cluster' has separate R1/R2/I1/I2 fastqs. Which of these are present will depend on the sequencing configuration.

There is also a configuration where R1 and R2 are interleaved in a single file, but I1/I2 are not.

Having access to this iterator let's me implement any multi-file iteration scheme I'd like.