### PR TITLE
use flate2 >= 1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["bio", "fastq", "parser"]
 [dependencies]
 memchr = ">=0.1"
 lz4 = "^1.20"
-flate2 = { version = ">=0.2.18", features = ["zlib"], default-features = false }
+flate2 = { version = ">=1.0", features = ["zlib"], default-features = false }
 
 [dev-dependencies]
 parasailors = ">=0.3"


### PR DESCRIPTION
The current code is not compatible with flate2 = "0.2", because `MultiGzDecoder::new()` returns `Result<_,_>` rather than `MultiGzDecoder`