### PR TITLE
Simplify parse_path by use niffler

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,8 +11,7 @@ keywords = ["bio", "fastq", "parser"]
 
 [dependencies]
 memchr = ">=0.1"
-lz4 = "^1.20"
-flate2 = { version = ">=0.2.18", features = ["zlib"], default-features = false }
+niffler = { version = ">=2.4.0" }
 
 [dev-dependencies]
 parasailors = ">=0.3"

--- a/examples/alignment_count.rs
+++ b/examples/alignment_count.rs
@@ -1,6 +1,6 @@
 use fastq::{parse_path, Record};
-use std::env::args;
 use parasailors as align;
+use std::env::args;
 
 extern crate fastq;
 extern crate parasailors;
@@ -12,29 +12,31 @@ const ADAPTER: &'static [u8] = b"AATGATACGGCGACCACCGAGA\
 fn main() {
     let filename = args().nth(1);
     let path = match filename.as_ref().map(String::as_ref) {
-        None | Some("-") => { None },
-        Some(name) => Some(name)
+        None | Some("-") => None,
+        Some(name) => Some(name),
     };
 
     let results = parse_path(path, |parser| {
         let nthreads = 2;
-        let results: Vec<usize> = parser.parallel_each(nthreads, |record_sets| {
-            let matrix = align::Matrix::new(align::MatrixType::Identity);
-            let profile = align::Profile::new(ADAPTER, &matrix);
-            let mut thread_total = 0;
+        let results: Vec<usize> = parser
+            .parallel_each(nthreads, |record_sets| {
+                let matrix = align::Matrix::new(align::MatrixType::Identity);
+                let profile = align::Profile::new(ADAPTER, &matrix);
+                let mut thread_total = 0;
 
-            for record_set in record_sets {
-                for record in record_set.iter() {
-                    let score = align::local_alignment_score(
-                            &profile, record.seq(), 8, 1);
-                    if score > 10 {
-                        thread_total += 1;
+                for record_set in record_sets {
+                    for record in record_set.iter() {
+                        let score = align::local_alignment_score(&profile, record.seq(), 8, 1);
+                        if score > 10 {
+                            thread_total += 1;
+                        }
                     }
                 }
-            }
-            thread_total
-        }).expect("Invalid fastq file");
+                thread_total
+            })
+            .expect("Invalid fastq file");
         results
-    }).expect("Invalid compression");
+    })
+    .expect("Invalid compression");
     println!("{}", results.iter().sum::<usize>());
 }

--- a/examples/bio-count.rs
+++ b/examples/bio-count.rs
@@ -1,7 +1,7 @@
+use bio::io::fastq::{Reader, Record};
 use std::io::stdin;
 use std::sync::mpsc::sync_channel;
 use std::thread::Builder;
-use bio::io::fastq::{Reader, Record};
 
 extern crate bio;
 
@@ -9,13 +9,16 @@ fn main() {
     let reader = Reader::new(stdin());
     let (tx, rx) = sync_channel::<Vec<Record>>(10);
 
-    let handle = Builder::new().name("worker".to_string()).spawn(move || {
-        let mut count: usize = 0;
-        while let Ok(val) = rx.recv() {
-            count += val.len();
-        }
-        count
-    }).unwrap();
+    let handle = Builder::new()
+        .name("worker".to_string())
+        .spawn(move || {
+            let mut count: usize = 0;
+            while let Ok(val) = rx.recv() {
+                count += val.len();
+            }
+            count
+        })
+        .unwrap();
 
     //let mut record = Record::new();
     //while let Ok(_) = reader.read(&mut record) {

--- a/examples/fastq-count-thread.rs
+++ b/examples/fastq-count-thread.rs
@@ -6,18 +6,21 @@ extern crate fastq;
 fn main() {
     let filename = args().nth(1);
     let path = match filename.as_ref().map(String::as_ref) {
-        None | Some("-") => { None },
-        Some(name) => Some(name)
+        None | Some("-") => None,
+        Some(name) => Some(name),
     };
 
     parse_path(path, |parser| {
-        let results: Vec<usize> = parser.parallel_each(1, |record_sets| {
-            let mut thread_total = 0;
-            for record_set in record_sets {
-                thread_total += record_set.len();
-            }
-            thread_total
-        }).expect("Invalid fastq file");
+        let results: Vec<usize> = parser
+            .parallel_each(1, |record_sets| {
+                let mut thread_total = 0;
+                for record_set in record_sets {
+                    thread_total += record_set.len();
+                }
+                thread_total
+            })
+            .expect("Invalid fastq file");
         println!("{}", results.iter().sum::<usize>());
-    }).expect("Invalid compression");
+    })
+    .expect("Invalid compression");
 }

--- a/examples/fastq-count.rs
+++ b/examples/fastq-count.rs
@@ -3,20 +3,22 @@ use std::env::args;
 
 extern crate fastq;
 
-
 fn main() {
     let filename = args().nth(1);
     let path = match filename.as_ref().map(String::as_ref) {
-        None | Some("-") => { None },
-        Some(name) => Some(name)
+        None | Some("-") => None,
+        Some(name) => Some(name),
     };
 
     let mut total: usize = 0;
     parse_path(path, |parser| {
-        parser.each(|_| {
-            total += 1;
-            true
-        }).expect("Invalid fastq file");
-    }).expect("Invalid compression");
+        parser
+            .each(|_| {
+                total += 1;
+                true
+            })
+            .expect("Invalid fastq file");
+    })
+    .expect("Invalid compression");
     println!("{}", total);
 }

--- a/examples/multiple-files.rs
+++ b/examples/multiple-files.rs
@@ -1,8 +1,7 @@
-use fastq::{parse_path, each_zipped};
+use fastq::{each_zipped, parse_path};
 use std::env::args;
 
 extern crate fastq;
-
 
 fn main() {
     let path1 = args().nth(1).expect("Need two input files.");
@@ -20,9 +19,12 @@ fn main() {
                     counts.1 += 1;
                 }
                 (true, true)
-            }).expect("Invalid record.");
-        }).expect("Unknown format for file 2.");
-    }).expect("Unknown format for file 1.");
+            })
+            .expect("Invalid record.");
+        })
+        .expect("Unknown format for file 2.");
+    })
+    .expect("Unknown format for file 1.");
 
     println!("Number of reads: ({}, {})", counts.0, counts.1);
 }

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -1,19 +1,17 @@
-use std::io::{Read, Result, ErrorKind};
-
+use std::io::{ErrorKind, Read, Result};
 
 pub struct Buffer {
     data: Box<[u8]>,
     start: usize,
-    end: usize
+    end: usize,
 }
-
 
 impl Buffer {
     pub fn new(size: usize) -> Buffer {
         Buffer {
             data: vec![0u8; size].into_boxed_slice(),
             start: 0,
-            end: 0
+            end: 0,
         }
     }
 
@@ -31,7 +29,7 @@ impl Buffer {
 
     pub fn replace_buffer(&mut self, mut buffer: Box<[u8]>) -> Box<[u8]> {
         let n_in_buffer = self.len();
-        let new_end = (n_in_buffer + 15) & !0x0f;  // make sure next read is aligned
+        let new_end = (n_in_buffer + 15) & !0x0f; // make sure next read is aligned
         let new_start = new_end.checked_sub(n_in_buffer).unwrap();
 
         assert!(buffer.len() >= new_end);
@@ -52,28 +50,34 @@ impl Buffer {
     /// Move data to the start of the buffer, freeing space at the end.
     pub fn clean(&mut self) {
         if self.start == 0 {
-            return
+            return;
         }
 
         let n_in_buffer = self.len();
-        let new_end = (n_in_buffer + 15) & !0x0f;  // make sure next read is aligned
+        let new_end = (n_in_buffer + 15) & !0x0f; // make sure next read is aligned
         let new_start = new_end.checked_sub(n_in_buffer).unwrap();
 
         if new_start >= self.start {
-            return
+            return;
         }
 
         let dest = self.data[new_start..].as_mut_ptr();
         let src = self.data[self.start..].as_ptr();
 
-        unsafe { ::std::ptr::copy(src, dest, n_in_buffer); }
+        unsafe {
+            ::std::ptr::copy(src, dest, n_in_buffer);
+        }
         self.start = new_start;
         self.end = new_end;
     }
 
     pub fn read_into<R: Read>(&mut self, reader: &mut R) -> Result<usize> {
         let n_free = self.n_free();
-        let num_read = if n_free < 4096 { n_free } else { n_free - n_free % 4096 };
+        let num_read = if n_free < 4096 {
+            n_free
+        } else {
+            n_free - n_free % 4096
+        };
 
         let dest = &mut self.data[self.end..self.end + num_read];
 
@@ -82,12 +86,15 @@ impl Buffer {
             match reader.read(dest) {
                 Err(e) => {
                     if e.kind() != ErrorKind::Interrupted {
-                        return Err(e)
+                        return Err(e);
                     }
-                },
-                Ok(val) => { n_read = val; break }
+                }
+                Ok(val) => {
+                    n_read = val;
+                    break;
+                }
             }
-        };
+        }
         self.end += n_read;
         Ok(n_read)
     }

--- a/src/thread_reader.rs
+++ b/src/thread_reader.rs
@@ -1,58 +1,66 @@
 //! Wrap a reader in a background thread.
 
-use std::io::{Result, Read, Error, ErrorKind, Cursor};
-use std::sync::mpsc::{Receiver, SyncSender, sync_channel};
-use std::thread;
+use std::io::{Cursor, Error, ErrorKind, Read, Result};
 use std::rc::Rc;
-
+use std::sync::mpsc::{sync_channel, Receiver, SyncSender};
+use std::thread;
 
 struct BufferMessage {
     buffer: Box<[u8]>,
     written: Result<usize>,
 }
 
-
 fn buffer_channel(bufsize: usize, queuelen: usize) -> (BufferSender, BufferReceiver) {
     assert!(queuelen >= 1);
     let (full_send, full_recv) = sync_channel(queuelen);
     let (empty_send, empty_recv) = sync_channel(queuelen);
     for _ in 0..queuelen {
-        empty_send.send(vec![0u8; bufsize].into_boxed_slice()).unwrap();
+        empty_send
+            .send(vec![0u8; bufsize].into_boxed_slice())
+            .unwrap();
     }
 
-    let buffer_sender = BufferSender { full_send: full_send, empty_recv: empty_recv };
-    let buffer_receiver = BufferReceiver { full_recv: full_recv, empty_send: Rc::new(empty_send) };
+    let buffer_sender = BufferSender {
+        full_send: full_send,
+        empty_recv: empty_recv,
+    };
+    let buffer_receiver = BufferReceiver {
+        full_recv: full_recv,
+        empty_send: Rc::new(empty_send),
+    };
     (buffer_sender, buffer_receiver)
 }
-
 
 struct BufferSender {
     full_send: SyncSender<BufferMessage>,
     empty_recv: Receiver<Box<[u8]>>,
 }
 
-
 impl BufferSender {
-    fn serve<F>(&mut self, mut func: F) where F: FnMut(Box<[u8]>) -> BufferMessage {
+    fn serve<F>(&mut self, mut func: F)
+    where
+        F: FnMut(Box<[u8]>) -> BufferMessage,
+    {
         while let Ok(buffer) = self.empty_recv.recv() {
             let reply = func(buffer);
             if self.full_send.send(reply).is_err() {
-                break
+                break;
             }
         }
     }
 }
-
 
 struct BufferReceiver {
     full_recv: Receiver<BufferMessage>,
     empty_send: Rc<SyncSender<Box<[u8]>>>,
 }
 
-
 impl BufferReceiver {
     fn next_reader(&mut self) -> Result<PartialReader> {
-        let data = self.full_recv.recv().map_err(|e| Error::new(ErrorKind::BrokenPipe, e))?;
+        let data = self
+            .full_recv
+            .recv()
+            .map_err(|e| Error::new(ErrorKind::BrokenPipe, e))?;
         Ok(PartialReader {
             available: data.written?,
             written: 0,
@@ -62,14 +70,12 @@ impl BufferReceiver {
     }
 }
 
-
 struct PartialReader {
     sender: Rc<SyncSender<Box<[u8]>>>,
     data: Option<Box<[u8]>>,
     available: usize,
     written: usize,
 }
-
 
 impl Drop for PartialReader {
     fn drop(&mut self) {
@@ -81,7 +87,6 @@ impl Drop for PartialReader {
     }
 }
 
-
 impl Read for PartialReader {
     fn read(&mut self, buffer: &mut [u8]) -> Result<usize> {
         let data = &self.data.as_ref().unwrap()[self.written..self.available];
@@ -91,20 +96,17 @@ impl Read for PartialReader {
     }
 }
 
-
 impl PartialReader {
     fn finished(&self) -> bool {
         self.available == self.written
     }
 }
 
-
 pub struct ThreadReader {
     handle: Option<thread::JoinHandle<()>>,
     receiver: BufferReceiver,
-    reader: Option<PartialReader>
+    reader: Option<PartialReader>,
 }
-
 
 impl Read for ThreadReader {
     fn read(&mut self, buffer: &mut [u8]) -> Result<usize> {
@@ -120,20 +122,21 @@ impl Read for ThreadReader {
     }
 }
 
-
 impl ThreadReader {
     fn new<R>(mut reader: R, buffsize: usize, queuelen: usize) -> ThreadReader
-        where R: Read + Send + 'static
+    where
+        R: Read + Send + 'static,
     {
         let (mut bufsend, bufrecv) = buffer_channel(buffsize, queuelen);
-        let handle = thread::Builder::new().name("reader-thread".into()).spawn(move || {
-            bufsend.serve(|mut buffer| {
-                BufferMessage {
+        let handle = thread::Builder::new()
+            .name("reader-thread".into())
+            .spawn(move || {
+                bufsend.serve(|mut buffer| BufferMessage {
                     written: reader.read(&mut buffer),
                     buffer: buffer,
-                }
+                })
             })
-        }).unwrap();
+            .unwrap();
 
         ThreadReader {
             handle: Some(handle),
@@ -142,7 +145,6 @@ impl ThreadReader {
         }
     }
 }
-
 
 /// Wrap a reader in a background thread.
 ///
@@ -158,29 +160,34 @@ impl ThreadReader {
 /// # Examples
 ///
 /// ```rust,no_run
-/// extern crate lz4;
+/// extern crate niffler;
 /// extern crate fastq;
 ///
 /// use std::io::stdin;
 /// use fastq::thread_reader;
 ///
 /// # fn main() {
-/// // lz4 is faster with a buffer size equal to the block size (default 4MB)
+/// // Compressed file reader is faster with a buffer size equal to the block size (default 4MB)
 /// const BUFSIZE: usize = 1 << 22;
 /// // The number of buffers the background thread fills, before it waits for
 /// // a consumer to catch up.
 /// const QUEUELEN: usize = 2;
 ///
-/// let file = lz4::Decoder::new(stdin()).unwrap();
+/// let (file, compression_format) = niffler::send::get_reader(Box::new(stdin())).unwrap();
 /// let out = thread_reader(BUFSIZE, QUEUELEN, file, |reader| {
 ///     // do something with the reader
 /// });
 /// # }
 /// ```
-pub fn thread_reader<R, F, O>(bufsize: usize, queuelen: usize, reader: R, func: F)
-    -> thread::Result<O>
-    where F: FnOnce(&mut ThreadReader) -> O,
-          R: Read + Send + 'static
+pub fn thread_reader<R, F, O>(
+    bufsize: usize,
+    queuelen: usize,
+    reader: R,
+    func: F,
+) -> thread::Result<O>
+where
+    F: FnOnce(&mut ThreadReader) -> O,
+    R: Read + Send + 'static,
 {
     let mut inner = ThreadReader::new(reader, bufsize, queuelen);
     let out = func(&mut inner);


### PR DESCRIPTION
Hi all,

As discuss in #7 I made this pull request to add niffler to support more type of compression and simplify code of fastq-rs.

I "test" my code with `cargo test` and by run:
```
cargo run --example multiple-files -- ~/dat/read_2nd/e_coli_k12_art_MSv3_R1.fastq{nothing|.gz|.bz2|.xz} ~/dat/read_2nd/e_coli_k12_art_MSv3_R2.fastq
```

I didn't check if this change have an impact on performance but previous code is quite similar to niffler source code so I think this change haven't an important impact.

Many change are just produce by automatic reformatting I could make a pull request without these changes.

Edit:

About zlib flate2 feature, niffler in unrelease version support control of downstream crate features, but if you want it I can accelerate niffler release process
